### PR TITLE
MTK11 compat: make CloudChemistry L / xi_SO2 coupled variables

### DIFF
--- a/src/cloud_chemistry.jl
+++ b/src/cloud_chemistry.jl
@@ -89,16 +89,16 @@ Output Variables:
             [description = "Inverse water density for LWC conversion", unit = u"m^3/g"]
     end
 
-    @parameters begin
-        L, [description = "Liquid water content", unit = u"g/m^3"]
-        xi_SO2,
+    @variables begin
+        # Primary state variables.
+        # L and xi_SO2 are coupled inputs (see SulfateFormation): variables, so
+        # `sulfate.L ~ L` is a connection equation with an unknown (a
+        # parameter ~ parameter connection is rejected by mtkcompile on MTK v11).
+        L(t), [description = "Liquid water content", unit = u"g/m^3"]
+        xi_SO2(t),
             [
                 description = "SO2 mixing ratio for lifetime calculation (dimensionless)", unit = u"1",
             ]
-    end
-
-    @variables begin
-        # Primary state variables
         T(t), [description = "Temperature", unit = u"K"]
         H_plus(t), [description = "Hydrogen ion concentration", unit = u"mol/m^3"]
         pH(t), [description = "Droplet pH (dimensionless)", unit = u"1"]
@@ -285,16 +285,16 @@ Input Variables:
             [description = "Reference concentration (1 M = 1000 mol/m³)", unit = u"mol/m^3"]
     end
 
-    @parameters begin
-        L, [description = "Liquid water content", unit = u"g/m^3"]
-        xi_SO2,
+    @variables begin
+        # Primary state variables.
+        # L and xi_SO2 are coupled inputs (see SulfateFormation): variables, so
+        # `sulfate.L ~ L` is a connection equation with an unknown (a
+        # parameter ~ parameter connection is rejected by mtkcompile on MTK v11).
+        L(t), [description = "Liquid water content", unit = u"g/m^3"]
+        xi_SO2(t),
             [
                 description = "SO2 mixing ratio for lifetime calculation (dimensionless)", unit = u"1",
             ]
-    end
-
-    @variables begin
-        # Primary state variables
         T(t), [description = "Temperature", unit = u"K"]
         pH_input(t), [description = "Input pH value (dimensionless)", unit = u"1"]
         H_plus(t), [description = "Hydrogen ion concentration", unit = u"mol/m^3"]
@@ -432,12 +432,13 @@ Parameters and other variables same as CloudChemistryFixedpH.
             [description = "Reference concentration (1 M = 1000 mol/m³)", unit = u"mol/m^3"]
     end
 
-    @parameters begin
-        L, [description = "Liquid water content", unit = u"g/m^3"]
-        xi_SO2, [description = "SO2 mixing ratio (dimensionless)", unit = u"1"]
-    end
-
     @variables begin
+        # L and xi_SO2 are coupled inputs (see SulfateFormation): variables, so
+        # `sulfate.L ~ L` is a connection equation with an unknown (a
+        # parameter ~ parameter connection is rejected by mtkcompile on MTK v11).
+        L(t), [description = "Liquid water content", unit = u"g/m^3"]
+        xi_SO2(t), [description = "SO2 mixing ratio (dimensionless)", unit = u"1"]
+
         # State variable - sulfate concentration
         SO4_2minus(t), [description = "Sulfate concentration", unit = u"mol/m^3"]
 

--- a/src/sulfate_formation.jl
+++ b/src/sulfate_formation.jl
@@ -371,12 +371,14 @@ Also calculates rate conversion factors (Section 7.4):
             [description = "Percent scaling factor (dimensionless)", unit = u"1"]
     end
 
-    @parameters begin
-        L, [description = "Liquid water content", unit = u"g/m^3"]
-        xi_SO2, [description = "SO2 mixing ratio (dimensionless)", unit = u"1"]
-    end
-
     @variables begin
+        # L and xi_SO2 are coupled inputs (supplied by the host/driver), not
+        # solve-time constants, so they are variables like every other input
+        # below. This lets a parent component wire them with `child.L ~ L`, a
+        # connection equation that contains an unknown (a parameter ~ parameter
+        # connection is rejected by mtkcompile on MTK v11).
+        L(t), [description = "Liquid water content", unit = u"g/m^3"]
+        xi_SO2(t), [description = "SO2 mixing ratio (dimensionless)", unit = u"1"]
         T(t), [description = "Temperature", unit = u"K"]
         H_plus(t), [description = "Hydrogen ion concentration", unit = u"mol/m^3"]
         SO2_aq(t), [description = "Aqueous SO2 concentration [SO2.H2O]", unit = u"mol/m^3"]

--- a/test/aqueous_chemistry_test.jl
+++ b/test/aqueous_chemistry_test.jl
@@ -441,3 +441,89 @@ end
     # Synergistic term should dominate when both metals are present
     @test R_synergy > R_Fe_only + R_Mn_only
 end
+
+# =============================================================================
+# Cloud chemistry compile + solve (L and xi_SO2 must be variables, not parameters)
+# =============================================================================
+
+@testitem "Cloud chemistry L/xi_SO2 are variables (no param ~ param)" setup = [AqueousSetup] tags = [:aqueous] begin
+    # L and xi_SO2 are coupled inputs and must be unknowns (variables) in every
+    # component that wires them with `sulfate.L ~ L`, so the connection is an
+    # equation with an unknown (a parameter ~ parameter connection is rejected
+    # by mtkcompile on MTK v11).
+    for F in [SulfateFormation, CloudChemistry, CloudChemistryFixedpH, CloudChemistryODE]
+        sys = F()
+        pnames = [string(ModelingToolkit.getname(p)) for p in parameters(sys)]
+        unames = [string(ModelingToolkit.getname(u)) for u in unknowns(sys)]
+        @test "L" ∉ pnames
+        @test "xi_SO2" ∉ pnames
+        @test "L" ∈ unames
+        @test "xi_SO2" ∈ unames
+    end
+end
+
+@testsnippet CloudChemSolveSetup begin
+    using Test
+    using ModelingToolkit
+    using ModelingToolkit: t_nounits as t
+    using Aerosol
+    using NonlinearSolve
+    using SciMLBase
+    using DynamicQuantities
+
+    # Drive a CloudChemistry box at a given NH3 mixing ratio and solve for the
+    # droplet pH (electroneutrality) and the S(IV) oxidation rates.
+    function solve_cloud(nh3_ppb)
+        P = 9.0e4
+        @named cc = CloudChemistry()
+        @constants begin
+            T_c = 283.0, [unit = u"K"]
+            pCO2 = 400e-6 * P, [unit = u"Pa"]
+            pSO2 = 1e-9 * P, [unit = u"Pa"]
+            pNH3 = nh3_ppb * 1e-9 * P, [unit = u"Pa"]
+            pHNO3 = 0.5e-9 * P, [unit = u"Pa"]
+            pH2O2 = 1e-9 * P, [unit = u"Pa"]
+            pO3 = 40e-9 * P, [unit = u"Pa"]
+            Fe_c = 1.0e-6, [unit = u"mol/m^3"]
+            Mn_c = 1.0e-7, [unit = u"mol/m^3"]
+            zero_c = 0.0, [unit = u"mol/m^3"]
+            L_c = 0.5, [unit = u"g/m^3"]
+            xiSO2_c = 1.0e-9, [unit = u"1"]
+        end
+        drivers = [
+            cc.T ~ T_c, cc.p_CO2 ~ pCO2, cc.p_SO2 ~ pSO2, cc.p_NH3 ~ pNH3,
+            cc.p_HNO3 ~ pHNO3, cc.p_H2O2 ~ pH2O2, cc.p_O3 ~ pO3,
+            cc.Fe_III ~ Fe_c, cc.Mn_II ~ Mn_c,
+            cc.Cl_minus ~ zero_c, cc.SO4_2minus ~ zero_c,
+            cc.L ~ L_c, cc.xi_SO2 ~ xiSO2_c, cc.charge_balance ~ 0,
+        ]
+        @named driver = System(drivers, t; systems = [cc])
+        sys = mtkcompile(driver)
+        sol = solve(
+            NonlinearProblem(sys, [cc.H_plus => 1.0e-3]), NewtonRaphson();
+            abstol = 1.0e-12,
+        )
+        return (sol, cc, sys)
+    end
+end
+
+@testitem "CloudChemistry compiles and solves to a sane pH + S(IV) rate" setup = [CloudChemSolveSetup] tags = [:aqueous] begin
+    # A driven CloudChemistry must mtkcompile (L/xi_SO2 are variables) and solve
+    # to a physical droplet pH with the S&P Ch.7 pH dependence.
+    sol_lo, cc, sys = solve_cloud(1.0)
+    @test length(unknowns(sys)) == 1                 # only H+ is solved; rest observed
+    @test SciMLBase.successful_retcode(sol_lo)
+
+    pH_lo = sol_lo[cc.pH]
+    @test isfinite(pH_lo)
+    @test 1.0 < pH_lo < 7.0                           # physical droplet pH
+    @test sol_lo[cc.R_total] > 0
+    # At low pH, H2O2 dominates S(IV) oxidation; the O3 pathway is suppressed.
+    @test sol_lo[cc.R_H2O2] > sol_lo[cc.R_O3]
+
+    # Adding NH3 (a base) raises pH and switches the O3 pathway on.
+    sol_hi, cc_hi, _ = solve_cloud(100.0)
+    @test SciMLBase.successful_retcode(sol_hi)
+    @test sol_hi[cc_hi.pH] > pH_lo
+    @test sol_hi[cc_hi.R_O3] > sol_lo[cc.R_O3]
+end


### PR DESCRIPTION

**compat fix · non-breaking in coupled use; standalone `SulfateFormation` parameter-map use needs a one-line migration**

## Motivation / Change
`L` (in-cloud LWC) and `xi_SO2` are coupled inputs; declare them as variables (not `@parameters`) in `SulfateFormation` (which consumes them) and in the three cloud-chemistry constructors that wire them down to it (`CloudChemistry`, `CloudChemistryFixedpH`, `CloudChemistryODE`) so `sulfate.L ~ L` is a proper connection equation under MTK v11.

## Why this departs from the current design
Upstream declares `L`/`xi_SO2` as `@parameters`, but upstream's **own** constructors already connect them with equations — `sulfate.L ~ L` / `sulfate.xi_SO2 ~ xi_SO2` appear inside `CloudChemistry`, `CloudChemistryFixedpH`, and `CloudChemistryODE` (cloud_chemistry.jl lines 208, 381, 504 on main). With both sides parameters these are parameter ~ parameter equations, which `mtkcompile` on MTK v11 rejects ("equations … have no unknowns/observables"). So under the currently supported MTK the three cloud-chemistry components cannot be compiled at all; the existing tests stay green only because they stop at `F() isa System` and never call `mtkcompile` or solve.

Making them variables (rather than, say, rewriting the connections as parameter assignments) is the right form because `L`/`xi_SO2` are physically time- and space-varying inputs: the downstream GasChem in-cloud sulfate coupling supplies LWC from met data, which a parameter cannot carry. This matches how every other coupled input in these components (`T`, `H_plus`, the partial pressures, …) is already declared.

Neither declaration had a default upstream, so no standalone default behavior is lost — a value always had to be supplied. Migration for legacy standalone use is one line: supply `sys.L ~ value` as a driver equation instead of a parameter-map entry (`child.L ~ driver` in downstream couplings).

## Validation
- New regression test asserts `L`/`xi_SO2` are unknowns (not parameters) in all four components — guards against the parameter ~ parameter form reappearing.
- New compile-and-solve test: a driven `CloudChemistry` box now `mtkcompile`s (previously impossible), reduces to a single unknown (`H_plus`, everything else observed), and solves to a physical droplet pH with the Seinfeld & Pandis Ch. 7 pH dependence — H2O2 dominates S(IV) oxidation at low pH, and adding NH3 raises pH and switches the O3 pathway on.
- Full-suite CI on this branch: failure set line-identical to the upstream/main baseline (8 pre-existing dependency-drift reference-value failures, untouched by this PR), +25 new passing assertions from the tests above.

## Notes
Prerequisite for the downstream GasChem het/cloud coupling PR (in-cloud SO2 → sulfate via `CloudChemistryFixedpH`).

---

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
