### PR TITLE
Write the water equilibrium in explicit assignable form (fixes MTK v11 init KeyError)

### DIFF
--- a/src/aqueous_equilibria.jl
+++ b/src/aqueous_equilibria.jl
@@ -98,8 +98,11 @@ Variables:
         # Temperature dependence of K_w (van't Hoff equation)
         K_w ~ K_w_298 * exp((-dH_Kw / R_gas) * (1 / T - 1 / T_ref)),
 
-        # Eq 7.11: Water equilibrium
-        K_w ~ H_plus * OH_minus,
+        # Eq 7.11: Water equilibrium, written explicitly as OH_minus = K_w/H_plus.
+        # K_w is fixed by the van't Hoff equation above and H_plus is set by the
+        # coupling, so the explicit form lets structural simplification assign
+        # OH_minus to this equation and eliminate it as an observed variable.
+        OH_minus ~ K_w / H_plus,
 
         # Eq 7.13: pH definition (pH = -log10([H+] in mol/L) = -log10([H+] in mol/m³ / 1000))
         pH ~ -log10(H_plus / C_ref),

--- a/test/aqueous_chemistry_test.jl
+++ b/test/aqueous_chemistry_test.jl
@@ -441,3 +441,22 @@ end
     # Synergistic term should dominate when both metals are present
     @test R_synergy > R_Fe_only + R_Mn_only
 end
+
+
+@testitem "water equilibrium is written in explicit assignable form" tags = [:aqueous] begin
+    using ModelingToolkit
+    # Contract: every OH_minus defining equation must be the explicit
+    # OH_minus ~ K_w/H_plus form (or a pure parent<->subsystem alias) so that
+    # OH_minus is assigned and eliminated as observed. The implicit form
+    # (K_w ~ H_plus * OH_minus) leaves OH_minus an unknown with no initial
+    # condition, which the gridded init_u then KeyErrors on under MTK v11.
+    cc = Aerosol.CloudChemistryFixedpH()
+    eqs = equations(cc)
+    idxs = findall(e -> endswith(string(e.lhs), "OH_minus(t)"), eqs)
+    @test !isempty(idxs)
+    for i in idxs
+        rhs = string(eqs[i].rhs)
+        @test occursin("H_plus", rhs) || endswith(rhs, "OH_minus(t)")
+    end
+    @test !any(e -> occursin("K_w", string(e.lhs)) && occursin("OH_minus", string(e.rhs)), eqs)
+end


### PR DESCRIPTION

**bugfix · non-breaking (algebraically identical)**

## Motivation
The implicit `K_w ~ H_plus*OH_minus` left `OH_minus` an unknown with no initial condition under MTK v11; the gridded `init_u` then `KeyError`ed on `…₊OH_minus`.

## Change
Write `OH_minus ~ K_w / H_plus` explicitly so structural simplification assigns and eliminates it as observed.

## Why this departs from the current design
This changes the form of an equation upstream ships (S&P Eq. 7.11), so to be explicit:

- **Algebraically identical.** `OH_minus ~ K_w/H_plus` ⇔ `K_w ~ H_plus*OH_minus` whenever `H_plus > 0`, which physically always holds (the same system defines `pH ~ -log10(H_plus/C_ref)`). No numerical value changes.
- **Root cause of the failure.** In `WaterEquilibrium`, `K_w` is already pinned by the van't Hoff equation immediately above, and `H_plus` is set by the coupling (electroneutrality or fixed pH). The only quantity Eq. 7.11 can determine is `OH_minus` — but in the implicit form structural simplification cannot assign `OH_minus` to that equation, so `OH_minus` is orphaned as an unknown with no defining equation and no default. Any gridded initialization that builds `ics[u]` for every unknown (the EarthSciMLBase CTM path) then fails with `KeyError: …₊OH_minus`.
- **Why this form and not an initial condition.** Adding a default/IC for `OH_minus` would paper over the KeyError but leave a redundant algebraic unknown; the explicit form is the canonical assignable form initialization requires — `mtkcompile` eliminates `OH_minus` as observed, so the compiled system has one fewer unknown and no residual equation to converge.

## Validation
- New test (`aqueous_chemistry_test.jl`): every `OH_minus` defining equation is the explicit form (or a pure alias), and the implicit form is absent.
- Full-suite CI on this branch: failure set identical to the upstream/main baseline (8 pre-existing dependency-drift reference-value failures, untouched by this PR), +5 new passing assertions (water-equilibrium contract).
- This fix is a prerequisite for the gridded-init path in the downstream GasChem het/cloud coupling work (separate PR). Author-side integration evidence (not reproducible from this repo): the gridded-init path that previously KeyErrored runs end-to-end in author-side coupled GEOS-Chem + Aerosol integration testing, where the full new-physics stack holds O3 r = 0.9981 against an author-side pre-change reference run over CONUS (whole-stack context, not validation of this one-line change).

---

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
