### PR TITLE
Add coupler types for CloudChemistryFixedpH and the aerosol distributions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -49,6 +49,7 @@ SymbolicUtils = "4.18.5"
 julia = "1"
 
 [extras]
+EarthSciMLBase = "e53f1632-a13c-4728-9402-0c66d48804b0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 EarthSciData = "a293c155-435f-439d-9c11-a083b6b47337"
 NonlinearSolve = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
@@ -59,4 +60,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [targets]
-test = ["Test", "Dates", "EarthSciData", "NonlinearSolve", "OrdinaryDiffEq", "Statistics", "Symbolics", "TestItemRunner"]
+test = ["Test", "Dates", "EarthSciData", "NonlinearSolve", "OrdinaryDiffEq", "Statistics", "Symbolics", "TestItemRunner", "EarthSciMLBase"]

--- a/src/cloud_chemistry.jl
+++ b/src/cloud_chemistry.jl
@@ -244,6 +244,15 @@ end
 # =============================================================================
 
 """
+Coupler type for [`CloudChemistryFixedpH`](@ref), exposing the in-cloud
+S(IV)→S(VI) oxidation rates (`R_H2O2`, `R_O3`, `R_FeMn`) for coupling to a
+gas-phase mechanism via `EarthSciMLBase.couple`.
+"""
+struct CloudChemistryFixedpHCoupler
+    sys::Any
+end
+
+"""
     CloudChemistryFixedpH(; name=:CloudChemFixedpH)
 
 Simplified cloud chemistry system with pH as an input parameter.
@@ -391,7 +400,8 @@ Input Variables:
     return System(
         eqs, t;
         systems = [water_eq, co2_eq, so2_eq, nh3_eq, hno3_eq, h2o2_eq, o3_eq, sulfate],
-        name
+        name,
+        metadata = Dict(CoupleType => CloudChemistryFixedpHCoupler)
     )
 end
 

--- a/src/size_distribution.jl
+++ b/src/size_distribution.jl
@@ -3,6 +3,15 @@ export UrbanAerosol, MarineAerosol, RuralAerosol, RemoteContinentalAerosol
 export FreeTroposphereAerosol, PolarAerosol, DesertAerosol
 
 """
+Coupler type for [`AerosolDistribution`](@ref), allowing it to provide the
+total aerosol surface-area concentration `S_t` (and other distribution moments)
+to other EarthSciML systems via `EarthSciMLBase.couple`.
+"""
+struct AerosolDistributionCoupler
+    sys::Any
+end
+
+"""
     AerosolDistribution(n_modes=3; name=:AerosolDistribution)
 
 Multi-modal lognormal aerosol size distribution following the parameterization of
@@ -139,7 +148,7 @@ Default parameter values correspond to the "Urban" distribution from Table 8.3.
         M_z ~ exp(-z / H_p),
     ]
 
-    return System(eqs, t; name)
+    return System(eqs, t; name, metadata = Dict(CoupleType => AerosolDistributionCoupler))
 end
 
 # -------------------------------------------------------------------

--- a/test/aqueous_chemistry_test.jl
+++ b/test/aqueous_chemistry_test.jl
@@ -443,3 +443,12 @@ end
     # Synergistic term should dominate when both metals are present
     @test R_synergy > R_Fe_only + R_Mn_only
 end
+
+
+@testitem "coupler metadata is mounted on the built systems" begin
+    using EarthSciMLBase
+    @test EarthSciMLBase.get_coupletype(Aerosol.CloudChemistryFixedpH()) ==
+          Aerosol.CloudChemistryFixedpHCoupler
+    @test EarthSciMLBase.get_coupletype(Aerosol.UrbanAerosol()) ==
+          Aerosol.AerosolDistributionCoupler
+end

--- a/test/aqueous_chemistry_test.jl
+++ b/test/aqueous_chemistry_test.jl
@@ -96,6 +96,8 @@ end
         sys = F()
         @test sys isa System
     end
+    # CloudChemistryFixedpH carries a Coupler type for EarthSciMLBase.couple.
+    @test isdefined(Aerosol, :CloudChemistryFixedpHCoupler)
 end
 
 # =============================================================================

--- a/test/size_distribution_test.jl
+++ b/test/size_distribution_test.jl
@@ -106,6 +106,9 @@ end
     @test any(contains("z"), param_names)
     @test any(contains("H_p"), param_names)
 
+    # AerosolDistribution carries a Coupler type for EarthSciMLBase.couple.
+    @test isdefined(Aerosol, :AerosolDistributionCoupler)
+
     # Test different number of modes
     sys2 = AerosolDistribution(2)
     @test length(equations(sys2)) == 10


### PR DESCRIPTION

**feature · non-breaking (enables couple())**

## Change
Mount `CoupleType` metadata (`CloudChemistryFixedpHCoupler`, `AerosolDistributionCoupler`) so downstream mechanisms can `couple2` against these systems. This follows the pattern the repo already uses for `ElementalCarbon` (`metadata = Dict(CoupleType => ElementalCarbonCoupler)` in elemental_carbon.jl); no new dependency — `EarthSciMLBase` is already a main dependency, it is only added to the test target here.

## Scope
Metadata-only: no behavioral change to any existing system — every parameter keeps its upstream declaration (including `D_p`'s hard error when omitted). The downstream coupling PR that consumes `S_t` supplies any evaluation-point value it needs at its own composition site.

## Validation
New test (`aqueous_chemistry_test.jl`): `get_coupletype` returns the mounted coupler for both constructors. (Adds EarthSciMLBase to test extras/targets.) Full-suite CI on this branch: failure set identical to the upstream/main baseline, +4 new passing assertions (coupler metadata + smoke asserts); all existing size-distribution and cloud-chemistry tests unchanged and green.

## Notes
Tag a release after merge (0.4.x); the downstream GasChem het/cloud coupling PR (`CloudChemistryFixedpH` in-cloud sulfate + `S_t`-based uptake) and the further GasChem aerosol-coupling PRs depend on this tag.

---

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
